### PR TITLE
--static in build instructions should be --static-dir

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,8 @@ class Gmpy2Build(build_ext):
             # --mpir or on Windows and MSVC
             _comp_args.append('DMPIR=1')
             self.libraries.append('mpir')
-            self.libraries.remove('gmp')
+            if 'gmp' in self.libraries:
+                self.libraries.remove('gmp')
             if ON_WINDOWS and not self.static:
                 # MSVC shared build
                 _comp_args.append('MSC_USE_DLL')
@@ -87,7 +88,7 @@ extensions = [
     Extension('gmpy2.gmpy2',
               sources=sources,
               include_dirs=['./src'],
-              libraries=['mpc','mpfr','gmp'],
+              libraries=['mpc','mpfr','mpir'],
               extra_compile_args=_comp_args,
               )
 ]

--- a/windows_build.txt
+++ b/windows_build.txt
@@ -163,21 +163,21 @@ xcopy /y c:\src\mpc\lib\x64\Release\*.lib c:\src\64\vs2015\lib\
 Compile gmpy2
 =============
 
-c:\32\Python26\python.exe setup.py build_ext --force --mpir --static=c:\src\32\vs2008 bdist_wininst
-c:\32\Python27\python.exe setup.py build_ext --force --mpir --static=c:\src\32\vs2008 bdist_wininst
-c:\32\Python33\python.exe setup.py build_ext --force --mpir --static=c:\src\32\vs2010 bdist_wininst
-c:\32\Python34\python.exe setup.py build_ext --force --mpir --static=c:\src\32\vs2010 bdist_wininst
-c:\32\Python35\python.exe setup.py build_ext --force --mpir --static=c:\src\32\vs2015 bdist_wininst
-c:\32\Python36\python.exe setup.py build_ext --force --mpir --static=c:\src\32\vs2015 bdist_wininst
-c:\32\Python37\python.exe setup.py build_ext --force --mpir --static=c:\src\32\vs2015 bdist_wininst
+c:\32\Python26\python.exe setup.py build_ext --force --mpir --static-dir=c:\src\32\vs2008 bdist_wininst
+c:\32\Python27\python.exe setup.py build_ext --force --mpir --static-dir=c:\src\32\vs2008 bdist_wininst
+c:\32\Python33\python.exe setup.py build_ext --force --mpir --static-dir=c:\src\32\vs2010 bdist_wininst
+c:\32\Python34\python.exe setup.py build_ext --force --mpir --static-dir=c:\src\32\vs2010 bdist_wininst
+c:\32\Python35\python.exe setup.py build_ext --force --mpir --static-dir=c:\src\32\vs2015 bdist_wininst
+c:\32\Python36\python.exe setup.py build_ext --force --mpir --static-dir=c:\src\32\vs2015 bdist_wininst
+c:\32\Python37\python.exe setup.py build_ext --force --mpir --static-dir=c:\src\32\vs2015 bdist_wininst
 
-c:\64\Python26\python.exe setup.py build_ext --force --mpir --static=c:\src\64\vs2008 bdist_wininst
-c:\64\Python27\python.exe setup.py build_ext --force --mpir --static=c:\src\64\vs2008 bdist_wininst
-c:\64\Python33\python.exe setup.py build_ext --force --mpir --static=c:\src\64\vs2010 bdist_wininst
-c:\64\Python34\python.exe setup.py build_ext --force --mpir --static=c:\src\64\vs2010 bdist_wininst
-c:\64\Python35\python.exe setup.py build_ext --force --mpir --static=c:\src\64\vs2015 bdist_wininst
-c:\64\Python36\python.exe setup.py build_ext --force --mpir --static=c:\src\64\vs2015 bdist_wininst
-c:\64\Python37\python.exe setup.py build_ext --force --mpir --static=c:\src\64\vs2015 bdist_wininst
+c:\64\Python26\python.exe setup.py build_ext --force --mpir --static-dir=c:\src\64\vs2008 bdist_wininst
+c:\64\Python27\python.exe setup.py build_ext --force --mpir --static-dir=c:\src\64\vs2008 bdist_wininst
+c:\64\Python33\python.exe setup.py build_ext --force --mpir --static-dir=c:\src\64\vs2010 bdist_wininst
+c:\64\Python34\python.exe setup.py build_ext --force --mpir --static-dir=c:\src\64\vs2010 bdist_wininst
+c:\64\Python35\python.exe setup.py build_ext --force --mpir --static-dir=c:\src\64\vs2015 bdist_wininst
+c:\64\Python36\python.exe setup.py build_ext --force --mpir --static-dir=c:\src\64\vs2015 bdist_wininst
+c:\64\Python37\python.exe setup.py build_ext --force --mpir --static-dir=c:\src\64\vs2015 bdist_wininst
 
 
 


### PR DESCRIPTION
Also, setup.py did not check if 'gmp' was in the list of libraries before trying to remove it, leading to ValueError possibly being raised.

It was also necessary to change 'gmp' to 'mpir' in the list of libraries. This may be because this list is used before build_extensions() has a chance to modify it.