### PR TITLE
fix building PyPI wheels (manylinux and macOS) on GitHub Actions

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - 'build-wheels.conf'
+  workflow_dispatch:
 
 jobs:
   build_wheels:
@@ -13,19 +14,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-latest]
+        os: [ubuntu-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
-      - uses: actions/setup-python@v1
-        name: Install Python
-        with:
-          python-version: '3.7'
+      - uses: actions/setup-python@v2
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==1.3.0
+          python -m pip install cibuildwheel==2.3.0
 
       - name: Build wheel
         run: |
@@ -34,10 +32,10 @@ jobs:
           CIBW_BEFORE_BUILD: bash scripts/before_ci_build.sh
           CIBW_SKIP: pp*
 
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v2
         with:
           name: wheels
-          path: ./wheelhouse
+          path: ./wheelhouse/*.whl
 
   windows_wheels:
     strategy:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -30,7 +30,7 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BEFORE_BUILD: bash scripts/before_ci_build.sh
-          CIBW_SKIP: pp*
+          CIBW_SKIP: pp* cp36-* cp310-*
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -30,7 +30,7 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BEFORE_BUILD: bash scripts/before_ci_build.sh
-          CIBW_SKIP: pp* cp36-* cp310-*
+          CIBW_SKIP: pp* cp36-* cp310-* cp*-musllinux*
 
       - uses: actions/upload-artifact@v2
         with:
@@ -41,22 +41,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
     runs-on: windows-latest
     defaults:
       run:
         shell: cmd /C CALL {0}
     steps:
       - uses: actions/checkout@master
-      - uses: goanpeca/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v2
         with:
-          miniconda-version: 4.10.3
+#          miniconda-version: 4.10.3
           auto-activate-base: false
           channels: "conda-forge"
           python-version: ${{ matrix.python-version }}
 
       - name: Install libraries
-        run: conda install mpir "mpfr>=4" mpc conda=4.10.3
+        run: conda install mpir "mpfr>=4" mpc # conda=4.10.3
 
       - name: Activate
         run: activate

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -50,13 +50,13 @@ jobs:
       - uses: actions/checkout@master
       - uses: goanpeca/setup-miniconda@v1
         with:
-          miniconda-version: 4.6.14
+          miniconda-version: 4.10.3
           auto-activate-base: false
           channels: "conda-forge"
           python-version: ${{ matrix.python-version }}
 
       - name: Install libraries
-        run: conda install mpir "mpfr>=4" mpc conda=4.6.14
+        run: conda install mpir "mpfr>=4" mpc conda=4.10.3
 
       - name: Activate
         run: activate

--- a/scripts/before_ci_build.sh
+++ b/scripts/before_ci_build.sh
@@ -1,9 +1,9 @@
-ver_gmp=6.2.0
+ver_gmp=6.2.1
 ver_mpfr=4.1.0
 ver_mpc=1.2.1
 if [ ! -f finish_before_ci_build ]; then
   if [[ "$OSTYPE" == "linux-gnu" ]]; then
-    curl -O https://gmplib.org/download/gmp/gmp-$ver_gmp.tar.lz
+    curl -O https://gmplib.org/download/gmp/gmp-$ver_gmp.tar.xz
     tar -xf gmp-$ver_gmp.tar.lz
     cd gmp-$ver_gmp && ./configure && make --enable-fat -j4 install && cd ../
 

--- a/scripts/before_ci_build.sh
+++ b/scripts/before_ci_build.sh
@@ -1,16 +1,22 @@
+ver_gmp=6.2.0
+ver_mpfr=4.1.0
+ver_mpc=1.2.1
 if [ ! -f finish_before_ci_build ]; then
   if [[ "$OSTYPE" == "linux-gnu" ]]; then
-    yum install -y wget lzip
-    wget https://gmplib.org/download/gmp/gmp-6.2.0.tar.lz
-    tar -xvf gmp-6.2.0.tar.lz
-    cd gmp-6.2.0 && ./configure && make --enable-fat -j4 && make install && cd ../
-    wget https://www.mpfr.org/mpfr-current/mpfr-4.0.2.tar.gz
-    tar -xvf mpfr-4.0.2.tar.gz
-    cd mpfr-4.0.2 && ./configure && make -j4 && make install && cd ../
-    wget https://ftp.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz
-    tar -xvf mpc-1.1.0.tar.gz
-    cd mpc-1.1.0 && ./configure && make -j4 && make install && cd ../
+    curl -O https://gmplib.org/download/gmp/gmp-$ver_gmp.tar.lz
+    tar -xf gmp-$ver_gmp.tar.lz
+    cd gmp-$ver_gmp && ./configure && make --enable-fat -j4 install && cd ../
+
+    curl -O https://www.mpfr.org/mpfr-current/mpfr-$ver_mpfr.tar.gz
+    tar -xf mpfr-$ver_mpfr.tar.gz
+    cd mpfr-$ver_mpfr && ./configure && make -j4 install && cd ../
+
+    curl -O https://ftp.gnu.org/gnu/mpc/mpc-$ver_mpc.tar.gz
+    tar -xf mpc-$ver_mpc.tar.gz
+    cd mpc-$ver_mpc && ./configure && make -j4 install && cd ../
+
     pip install Cython
+
   elif [[ "$OSTYPE" == "darwin"* ]]; then
     brew install gmp mpfr libmpc
   fi

--- a/scripts/before_ci_build.sh
+++ b/scripts/before_ci_build.sh
@@ -1,11 +1,10 @@
-ver_gmp=6.2.1
+ver_gmp=6.2.1 # we get instead one from the system, it's version 5.something
+              # - as the one built from source apparenly clashed, then the gmp
+	      # header cannot be found while building the wheel.
 ver_mpfr=4.1.0
 ver_mpc=1.2.1
 if [ ! -f finish_before_ci_build ]; then
   if [[ "$OSTYPE" == "linux-gnu" ]]; then
-#    curl -O https://gmplib.org/download/gmp/gmp-$ver_gmp.tar.xz
-#    tar -xf gmp-$ver_gmp.tar.lz
-#    cd gmp-$ver_gmp && ./configure && make --enable-fat -j4 install && cd ../
     yum -y install gmp-devel
 
     curl -O https://www.mpfr.org/mpfr-current/mpfr-$ver_mpfr.tar.gz

--- a/scripts/before_ci_build.sh
+++ b/scripts/before_ci_build.sh
@@ -3,9 +3,10 @@ ver_mpfr=4.1.0
 ver_mpc=1.2.1
 if [ ! -f finish_before_ci_build ]; then
   if [[ "$OSTYPE" == "linux-gnu" ]]; then
-    curl -O https://gmplib.org/download/gmp/gmp-$ver_gmp.tar.xz
-    tar -xf gmp-$ver_gmp.tar.lz
-    cd gmp-$ver_gmp && ./configure && make --enable-fat -j4 install && cd ../
+#    curl -O https://gmplib.org/download/gmp/gmp-$ver_gmp.tar.xz
+#    tar -xf gmp-$ver_gmp.tar.lz
+#    cd gmp-$ver_gmp && ./configure && make --enable-fat -j4 install && cd ../
+    yum -y install gmp-devel
 
     curl -O https://www.mpfr.org/mpfr-current/mpfr-$ver_mpfr.tar.gz
     tar -xf mpfr-$ver_mpfr.tar.gz


### PR DESCRIPTION
I have not had time to fix musllinux wheels too --- they are run on a different Linux platform, which does not have `yum`, so there should be more complicated script to set-up gmp/mpfr/mpc.

I also tried to do something with Windows build, so far without success, but I think this PR has merit nevertheless.
We can now test the built wheels (see e.g. Artifacts at the bottom of https://github.com/dimpase/gmpy2/actions/runs/1536807280)
and hopefully they can uploaded to PyPI.
